### PR TITLE
docs: add installation line to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An opinionated ESLint plugin for sorting and grouping imports automatically.
 Install with `pnpm`:
 
 ```bash
-pnpm add -D @bastidood/eslint-plugin-imsort
+pnpm add --save-dev @bastidood/eslint-plugin-imsort
 ```
 
 Or with `npm`:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ An opinionated ESLint plugin for sorting and grouping imports automatically.
 
 [`sort-imports`]: https://eslint.org/docs/latest/rules/sort-imports
 
+Install with `pnpm`:
+
+```bash
+pnpm add -D @bastidood/eslint-plugin-imsort
+```
+
+Or with `npm`:
+
+```bash
+npm install --save-dev @bastidood/eslint-plugin-imsort
+```
+
 ### ESLint Flat Config (recommended!)
 
 Add the plugin to your `eslint.config.js`:


### PR DESCRIPTION
🌟 This PR adds a line in the README with installation commands for `pnpm` and `npm`:

```bash
pnpm add --save-dev @bastidood/eslint-plugin-imsort
```

```bash
npm install --save-dev @bastidood/eslint-plugin-imsort
```